### PR TITLE
Ajuste de definição do método getAnnotations no prototype

### DIFF
--- a/annotation.js
+++ b/annotation.js
@@ -13,7 +13,13 @@ JSON.clone = function (value) {
 /* -------------------------------- GET ANNOTATIONS --------------------------------  */
 global = global || {};
 global.annotationsDebug = true;
-Object.prototype.getAnnotations = function (_typeQueryEnum = "DATA", _maxLevel = 2) {
+
+Object.defineProperty(Object.prototype, "getAnnotations", {
+    enumerable: false,
+    value: getAnnotations
+});
+
+function getAnnotations(_typeQueryEnum = "DATA", _maxLevel = 2) {
     var self = this;
     var typeQueryEnum = _typeQueryEnum;
     var objects = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "annotation-js",
-    "version": "1.3.13",
+    "version": "1.3.14",
     "description": "Annotation for Javascript language with navigation in subclasses",
     "main": "annotation.js",
     "scripts": {


### PR DESCRIPTION
A alteração evita o nome do método seja listado ao fazer um for in no objeto.